### PR TITLE
Add aarch64, llvm, static target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - '{ config = "x86_64-unknown-linux-musl"; useLLVM = false; isStatic = false;  }'
           - '{ config = "x86_64-unknown-linux-musl"; useLLVM = true; isStatic = false;  }'
           - '{ config = "x86_64-unknown-linux-musl"; useLLVM = true; isStatic = true;  }'
+          - '{ config = "aarch64-unknown-linux-musl"; useLLVM = true; isStatic = true;  }'
           # Broken targets
           # - '{ config = "x86_64-unknown-linux-musl"; useLLVM = false; isStatic = true;  }'
           # - '{ config = "x86_64-unknown-linux-gnu"; useLLVM = false; isStatic = false;  }'

--- a/tests/crates/build_all.sh
+++ b/tests/crates/build_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 


### PR DESCRIPTION
We are using this target and it seems to be working fine so it would be nice to have it on cachix. However when I tried to run the "Test {default,example} shell" they failed.

The only failing crate is rocksdb:

/nix/store/...-glibc-2.37-8-dev/include/gnu/stubs.h:7:11: fatal error: 'gnu/stubs-32.h' file not found

The other crates compile fine. This is on x86_64 NixOS.