### PR TITLE
Propagate config attribute

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,10 +4,11 @@ final: prev: {
     { src
     , localSystem
     , crossSystem ? null
+    , config ? { }
     , overlays ? [ ]
     }:
     let
-      localPkgs = import src { inherit localSystem; };
+      localPkgs = import src { inherit localSystem config; };
       stdenv = localPkgs.stdenv;
 
       patchedPkgs = localPkgs.applyPatches {
@@ -27,7 +28,7 @@ final: prev: {
       crossOverlay = import ./.;
     in
     import nixpkgs {
-      inherit localSystem crossSystem;
+      inherit localSystem crossSystem config;
       overlays = [ crossOverlay ] ++ overlays;
     };
 } // (import ./lib final prev)

--- a/utils/nixpkgs.nix
+++ b/utils/nixpkgs.nix
@@ -21,7 +21,7 @@ let
 in
 # Make cross system packages.
 pkgs.mkCrossPkgs {
-  inherit src localSystem crossSystem;
+  inherit src localSystem crossSystem config;
   # Setup extra overlays.
   overlays = [
     (import lockFile.rust-overlay)


### PR DESCRIPTION
Otherwise it is impossible to specify `allowUnfree = true` or `permittedInsecurePackages`.